### PR TITLE
Add completion percentage to analytics screen

### DIFF
--- a/src/logic/streak.rs
+++ b/src/logic/streak.rs
@@ -39,6 +39,7 @@ pub fn calculate_analytics(runs: &[Run]) -> Analytics {
         .filter(|(&date, &distance)| date >= year_start && distance >= DAILY_GOAL_MILES)
         .count() as i32;
     let days_remaining_to_year_goal = 365 - days_with_goal_met_this_year;
+    let year_goal_completion_percentage = (days_with_goal_met_this_year as f64 / 365.0) * 100.0;
 
     Analytics {
         current_streak,
@@ -51,6 +52,7 @@ pub fn calculate_analytics(runs: &[Run]) -> Analytics {
         runs_this_year,
         recent_trend,
         days_remaining_to_year_goal,
+        year_goal_completion_percentage,
     }
 }
 

--- a/src/models/analytics.rs
+++ b/src/models/analytics.rs
@@ -12,6 +12,7 @@ pub struct Analytics {
     pub runs_this_year: u32,
     pub recent_trend: Vec<DailyData>,
     pub days_remaining_to_year_goal: i32,
+    pub year_goal_completion_percentage: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -33,6 +34,7 @@ impl Analytics {
             runs_this_year: 0,
             recent_trend: Vec::new(),
             days_remaining_to_year_goal: 365,
+            year_goal_completion_percentage: 0.0,
         }
     }
 }

--- a/src/ui/screens/analytics.rs
+++ b/src/ui/screens/analytics.rs
@@ -46,9 +46,13 @@ fn render_streak(f: &mut Frame, area: Rect, state: &AnalyticsState) {
     };
 
     let days_remaining_text = if state.analytics.days_remaining_to_year_goal <= 0 {
-        "Goal Complete! 🎉".to_string()
+        "Goal Complete! 🎉 (100.0%)".to_string()
     } else {
-        format!("{} days", state.analytics.days_remaining_to_year_goal)
+        format!(
+            "{} days ({:.1}%)",
+            state.analytics.days_remaining_to_year_goal,
+            state.analytics.year_goal_completion_percentage
+        )
     };
 
     let text = vec![


### PR DESCRIPTION
## Summary
Adds a completion percentage display to the analytics screen showing progress toward the 365-day year goal.

## Changes
- **Data Model**: Added `year_goal_completion_percentage` field to `Analytics` struct
- **Calculation**: Computes percentage as `(days_with_goal_met / 365) × 100.0`
- **UI Display**: Shows percentage alongside days remaining in the Streaks section

## Display Format
- **In Progress**: `"X days (Y.Y%)"` - Shows remaining days and current completion percentage
- **Goal Complete**: `"Goal Complete! 🎉 (100.0%)"` - Celebrates when 365 days achieved

## Technical Details
- Reuses existing `days_with_goal_met_this_year` calculation for efficiency
- Format displays one decimal place for precision
- Color coding follows existing theme (green/yellow/white based on progress)

## Testing
- ✅ Builds successfully with `cargo build`
- ✅ No new clippy warnings introduced
- ✅ Code formatted with `cargo fmt`

## Files Changed
- `src/models/analytics.rs` - Added percentage field
- `src/logic/streak.rs` - Implemented calculation
- `src/ui/screens/analytics.rs` - Updated display

🤖 Generated with [Claude Code](https://claude.com/claude-code)