### PR TITLE
Add monthly mileage breakdown to analytics screen

### DIFF
--- a/src/models/analytics.rs
+++ b/src/models/analytics.rs
@@ -16,12 +16,22 @@ pub struct Analytics {
     pub average_distance_this_week: f64,
     pub average_distance_this_month: f64,
     pub average_distance_this_year: f64,
+    pub monthly_breakdown: Vec<MonthlyData>,
 }
 
 #[derive(Debug, Clone)]
 pub struct DailyData {
     pub date: NaiveDate,
     pub distance: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct MonthlyData {
+    pub year: i32,
+    pub month: u32,
+    pub total_distance: f64,
+    pub run_count: u32,
+    pub average_distance: f64,
 }
 
 impl Analytics {
@@ -41,6 +51,7 @@ impl Analytics {
             average_distance_this_week: 0.0,
             average_distance_this_month: 0.0,
             average_distance_this_year: 0.0,
+            monthly_breakdown: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `MonthlyData` struct to track monthly running statistics
- Calculate and display last 12 months of mileage data on analytics screen
- Show total distance, run count, and average per month
- Color code months by distance (green ≥50mi, yellow ≥25mi, white otherwise)

## Changes
- `src/models/analytics.rs`: Added `MonthlyData` struct and `monthly_breakdown` field
- `src/logic/streak.rs`: Added `calculate_monthly_breakdown()` function
- `src/ui/screens/analytics.rs`: Added "Mileage by Month" section to analytics screen

## Test plan
- [x] `cargo build` compiles successfully
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [ ] Launch app and verify monthly breakdown displays on analytics screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)